### PR TITLE
Update the define check to match the pattern used in namespaced builds

### DIFF
--- a/jquery-require-sample/webapp/scripts/require-jquery.js
+++ b/jquery-require-sample/webapp/scripts/require-jquery.js
@@ -10979,6 +10979,6 @@ jQuery.each([ "Height", "Width" ], function( i, name ) {
 window.jQuery = window.$ = jQuery;
 })(window);
 //Register jQuery as a module.
-if (typeof define !== "undefined" && define.amd) {
+if (typeof define === "function" && define.amd) {
     define('jquery',[], function() {return jQuery });
 }

--- a/parts/post.js
+++ b/parts/post.js
@@ -1,5 +1,5 @@
 
 //Register jQuery as a module.
-if (typeof define !== "undefined" && define.amd) {
+if (typeof define === "function" && define.amd) {
     define('jquery',[], function() {return jQuery });
 }


### PR DESCRIPTION
Simple change to match the pattern that works with the namespaced r.js builds.

i.e. for going from 

```
if (typeof define === "function" && define.amd) {
   define('jquery',[], function() {return jQuery });
}
```

to

```
 if (typeof myNamespace.define === "function" && myNamespace.define.amd) {
  myNamespace.define('jquery',[], function() {return jQuery });
}
```

Thanks again for putting in that support, it's already been a big help.
